### PR TITLE
chore: specify Node.js version in build configuration to ensure compatibility

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,7 @@ applications:
       phases:
         preBuild:
           commands:
+            - nvm use 22
             - corepack enable
             - pnpm install --frozen-lockfile
         build:


### PR DESCRIPTION
config amplify to use node 22